### PR TITLE
A minor speed improvement?

### DIFF
--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -100,7 +100,7 @@
   function open_modal_from_link(event) {
     event.preventDefault();
     var target = $(this).attr('href');
-    if(target.match(/^#/)) { // DOM id
+    if(/^#/.test(target)) { // DOM id
       $(target).modal();
     } else { // AJAX
       $.get(target, {}, function(html) {


### PR DESCRIPTION
`String.match` returns unnecessary array info while `Regex.test` returns only a true or false, which is all we need.

Theoretically, this will be faster. Barely :)
