### PR TITLE
When invoking manually, make sure the $ selection is not empty

### DIFF
--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -35,7 +35,7 @@
 
   $.modal = function(el, options){
     var self = this;
-    this.$elm = $(el);
+    this.$elm = el;
     this.options = $.extend({},$.modal.defaults, options);
     
     if(this.$elm.attr('href')) {
@@ -118,9 +118,8 @@
   };
 
   $.fn.modal = function(options){
-    return this.each(function(){
-      new $.modal(this, options);
-    });
+    if (this.length === 1) { new $.modal(this, options); }
+    return this;
   };
 
   // Automatically bind links with rel="modal:close" to, well, close the modal.


### PR DESCRIPTION
I was just checking to see what happens when invoking the modal manually, and I used the $('#sticky') example from examples. As we don't have a #sticky element in the DOM, the modal just display the blocker.

I could use something like

return this.each(function(el) { new $.modal(el, options) }

but it doesn't make sense for this type of plugin as we should not have more than one element selected.
