### PR TITLE
When invoking manually, make sure the $ selection is not empty

### DIFF
--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -118,7 +118,7 @@
   };
 
   $.fn.modal = function(options){
-    new $.modal(this, options);
+    if(this.length === 1) { new $.modal(this, options); }
     return this;
   };
 


### PR DESCRIPTION
I was just checking to see what happens when invoking the modal manually, and I used the $('#sticky') example from examples. As we don't have a #sticky element in the DOM, the modal just display the blocker.
