### PR TITLE
Use position:absolute for modal bigger than window

### DIFF
--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -143,14 +143,30 @@
     },
 
     center: function() {
-      this.$elm.css({
-        position: 'fixed',
-        top: "50%",
-        left: "50%",
-        marginTop: - (this.$elm.outerHeight() / 2),
-        marginLeft: - (this.$elm.outerWidth() / 2),
-        zIndex: this.options.zIndex + 1
-      });
+      var windowHeight = $(window).height();
+      var windowWidth = $(window).width();
+      var modalHeight = this.$elm.outerHeight();
+      var modalWidth = this.$elm.outerWidth();
+
+      if (windowWidth > modalWidth && windowHeight > modalHeight) {
+        this.$elm.css({
+            position: 'fixed',
+            top: "50%",
+            left: "50%",
+            marginTop: - (modalHeight / 2),
+            marginLeft: - (modalWidth / 2),
+            zIndex: this.options.zIndex + 1
+        });
+      } else {
+        this.$elm.css({
+            position: 'absolute',
+            top: $(document).scrollTop(),
+            left: Math.max(0, ((windowWidth - modalWidth) / 2)),
+            marginTop: 0,
+            marginLeft: 0,
+            zIndex: this.options.zIndex + 1
+        });
+      }
     },
 
     //Return context for custom events


### PR DESCRIPTION
When modal width or height is greater than available window area,
center method uses position:absolute instead of fixed, reset margins
and calculate new top and left position.

Please note I didn't updated minified version, sorry!