### PR TITLE
Fix blocker z-index issue

### DIFF
--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -41,6 +41,7 @@
       }
     } else {
       this.$elm = el;
+      this.$body.append(this.$elm);
       this.open();
     }
   };


### PR DESCRIPTION
To avoid modal going behind the blocker. related to #70
Same fix as https://github.com/dei79/jquery-modal-rails/pull/14/files in any element type of designated modal content.
