### PR TITLE
Fix jQuery Bower dependency to be less strict.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "modal"
   ],
   "dependencies": {
-    "jquery": "~1.8.0"
+    "jquery": "1.8.0 - 2.1.x"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
Please consider merging this. I needed the change because I'm using jQuery 2.1 in my project, and would like to use jQuery modal in it as well. Nothing has broken so far in my application, so it appears that jquery-modal simply is compatible with newer versions of jQuery.