### PR TITLE
fix typo README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ However, when this occurs, you will probably want to at least re-center the moda
 
 # Checking current state
 
-Use `$.model.isActive()` to check if a modal is currently being displayed.
+Use `$.modal.isActive()` to check if a modal is currently being displayed.
 
 # Options
 


### PR DESCRIPTION
Fixed typo $.model.isActive() -> $.modal.isActive().