### PR TITLE
Publish to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "jquery-modal",
+  "version": "0.5.5",
+  "description": "The simplest possible modal for jQuery",
+  "license": "MIT"
+}


### PR DESCRIPTION
Users with Browserify would appreciate if you could publish to npm.
To do that you need to accept this pull request, then [publish your package](https://docs.npmjs.com/getting-started/publishing-npm-packages).
