### PR TITLE
Refactor: wrap .modal in .blocker (fix #69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,14 +149,6 @@ Similar to how links can be automatically bound to open modals, they can be boun
 
 _(Note that modals loaded with AJAX are removed from the DOM when closed)._
 
-# Resizing
-
-There's really no need to manually resize modals, since the default styles don't specify a fixed height; modals will expand vertically (like a normal HTML element) to fit their contents.
-
-However, when this occurs, you will probably want to at least re-center the modal in the viewport:
-
-    $.modal.resize()
-
 # Checking current state
 
 Use `$.modal.isActive()` to check if a modal is currently being displayed.
@@ -166,9 +158,6 @@ Use `$.modal.isActive()` to check if a modal is currently being displayed.
 These are the supported options and their default values:
 
     $.modal.defaults = {
-      overlay: "#000",        // Overlay color
-      opacity: 0.75,          // Overlay opacity
-      zIndex: 1,              // Overlay z-index.
       escapeClose: true,      // Allows the user to close the modal by pressing `ESC`
       clickClose: true,       // Allows the user to close the modal by clicking the overlay
       closeText: 'Close',     // Text content for the close <a> tag.

--- a/examples/index.html
+++ b/examples/index.html
@@ -25,6 +25,10 @@
     td { border: 1px solid #eee; padding: 15px; }
     td pre { margin: 0; }
 
+    body > .modal {
+      display: none;
+    }
+
     /* Example 2 (login form) */
     .login_form.modal {
       border-radius: 0;
@@ -134,8 +138,8 @@
 
 <hr />
 
-<h2>Example 3: resizing</h2>
-<p>This <a href="#ex3" rel="modal:open">example</a> shows how <code>resize()</code> can be invoked on a modal.</p>
+<h2>Example 3: adjusting to content</h2>
+<p>This <a href="#ex3" rel="modal:open">example</a> shows how modals are centered automatically. It also demonstrates how a vertical scrollbar appears whenever the modal content overflows.</p>
 <div id="ex3" class="modal">
   <p><a id="more" href="#more">More!</a></p>
   <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.</p>
@@ -325,7 +329,6 @@ $('#manual-ajax').click(function(event) {
 
     $('#more').click(function() {
       $(this).parent().after($(this).parent().next().clone());
-      $.modal.resize();
       return false;
     });
 

--- a/jquery.modal.css
+++ b/jquery.modal.css
@@ -1,8 +1,14 @@
 .blocker {
+  position: fixed;
+  top: 0; right: 0; bottom: 0; left: 0;
+  width: 100%; height: 100%;
+  overflow: auto;
+  z-index: 1;
   padding: 20px;
   box-sizing: border-box;
   background-color: rgb(0,0,0);
   background-color: rgba(0,0,0,0.75);
+  text-align: center;
 }
 .blocker:before{
   content: "";
@@ -12,7 +18,10 @@
   margin-right: -0.05em;
 }
 .modal {
-  display: none;
+  display: inline-block;
+  vertical-align: middle;
+  position: relative;
+  z-index: 2;
   width: 400px;
   background: #fff;
   padding: 15px 30px;

--- a/jquery.modal.css
+++ b/jquery.modal.css
@@ -1,3 +1,16 @@
+.blocker {
+  padding: 20px;
+  box-sizing: border-box;
+  background-color: rgb(0,0,0);
+  background-color: rgba(0,0,0,0.75);
+}
+.blocker:before{
+  content: "";
+  display: inline-block;
+  height: 100%;
+  vertical-align: middle;
+  margin-right: -0.05em;
+}
 .modal {
   display: none;
   width: 400px;
@@ -13,6 +26,7 @@
   -o-box-shadow: 0 0 10px #000;
   -ms-box-shadow: 0 0 10px #000;
   box-shadow: 0 0 10px #000;
+  text-align: left;
 }
 
 .modal a.close-modal {

--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -160,11 +160,6 @@
     return that;
   };
 
-  $.modal.resize = function() {
-    if (!current) return;
-    current.resize();
-  };
-
   // Returns if there currently is an active modal
   $.modal.isActive = function () {
     return current ? true : false;

--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -18,6 +18,7 @@
       if (/^#/.test(target)) {
         this.$elm = $(target);
         if (this.$elm.length !== 1) return null;
+        this.$body.append(this.$elm);
         this.open();
       //AJAX
       } else {
@@ -65,7 +66,10 @@
           if (event.which == 27) $.modal.close();
         });
       }
-      if (this.options.clickClose) this.blocker.click($.modal.close);
+      if (this.options.clickClose) this.blocker.click(function(e){
+        if (e.target==this)
+          $.modal.close();
+      });
     },
 
     close: function() {
@@ -75,30 +79,35 @@
     },
 
     block: function() {
-      var initialOpacity = this.options.doFade ? 0 : this.options.opacity;
       this.$elm.trigger($.modal.BEFORE_BLOCK, [this._ctx()]);
       this.blocker = $('<div class="jquery-modal blocker"></div>').css({
         top: 0, right: 0, bottom: 0, left: 0,
         width: "100%", height: "100%",
         position: "fixed",
+        overflow: "auto",
         zIndex: this.options.zIndex,
-        background: this.options.overlay,
-        opacity: initialOpacity
+        "text-align": "center"
       });
+      this.$body.css('overflow','hidden');
       this.$body.append(this.blocker);
       if(this.options.doFade) {
-        this.blocker.animate({opacity: this.options.opacity}, this.options.fadeDuration);
+        this.blocker.css('opacity',0).animate({opacity: 1}, this.options.fadeDuration);
       }
       this.$elm.trigger($.modal.BLOCK, [this._ctx()]);
     },
 
     unblock: function() {
       if(this.options.doFade) {
+        var self=this;
         this.blocker.fadeOut(this.options.fadeDuration, function() {
-          $(this).remove();
+          self.blocker.children().appendTo(self.$body);
+          self.blocker.remove();
+          self.$body.css('overflow','');
         });
       } else {
+        this.blocker.children().appendTo(this.$body);
         this.blocker.remove();
+        this.$body.css('overflow','');
       }
     },
 
@@ -109,9 +118,10 @@
         this.$elm.append(this.closeButton);
       }
       this.$elm.addClass(this.options.modalClass + ' current');
+      this.$elm.appendTo(this.blocker);
       this.center();
       if(this.options.doFade) {
-        this.$elm.fadeIn(this.options.fadeDuration);
+        this.$elm.css('opacity',0).animate({opacity: 1}, this.options.fadeDuration);
       } else {
         this.$elm.show();
       }
@@ -145,11 +155,9 @@
 
     center: function() {
       this.$elm.css({
-        position: 'fixed',
-        top: "50%",
-        left: "50%",
-        marginTop: - (this.$elm.outerHeight() / 2),
-        marginLeft: - (this.$elm.outerWidth() / 2),
+        display: "inline-block",
+        "vertical-align": "middle",
+        position: "relative",
         zIndex: this.options.zIndex + 1
       });
     },

--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -80,14 +80,7 @@
 
     block: function() {
       this.$elm.trigger($.modal.BEFORE_BLOCK, [this._ctx()]);
-      this.blocker = $('<div class="jquery-modal blocker"></div>').css({
-        top: 0, right: 0, bottom: 0, left: 0,
-        width: "100%", height: "100%",
-        position: "fixed",
-        overflow: "auto",
-        zIndex: this.options.zIndex,
-        "text-align": "center"
-      });
+      this.blocker = $('<div class="jquery-modal blocker"></div>');
       this.$body.css('overflow','hidden');
       this.$body.append(this.blocker);
       if(this.options.doFade) {
@@ -119,7 +112,6 @@
       }
       this.$elm.addClass(this.options.modalClass + ' current');
       this.$elm.appendTo(this.blocker);
-      this.center();
       if(this.options.doFade) {
         this.$elm.css('opacity',0).animate({opacity: 1}, this.options.fadeDuration);
       } else {
@@ -153,23 +145,11 @@
       if (this.spinner) this.spinner.remove();
     },
 
-    center: function() {
-      this.$elm.css({
-        display: "inline-block",
-        "vertical-align": "middle",
-        position: "relative",
-        zIndex: this.options.zIndex + 1
-      });
-    },
-
     //Return context for custom events
     _ctx: function() {
       return { elm: this.$elm, blocker: this.blocker, options: this.options };
     }
   };
-
-  //resize is alias for center for now
-  $.modal.prototype.resize = $.modal.prototype.center;
 
   $.modal.close = function(event) {
     if (!current) return;
@@ -191,9 +171,6 @@
   }
 
   $.modal.defaults = {
-    overlay: "#000",
-    opacity: 0.75,
-    zIndex: 1,
     escapeClose: true,
     clickClose: true,
     closeText: 'Close',


### PR DESCRIPTION
Hi,

First of all thanks for sharing that plugin. It's light and functional, and that's all we need :)

The only blocking issue is the inability to scroll overflowing content (#69).

@alexgalli (#67) and @pawel-piskorz (#75) suggested two approaches to fix it, which both have the advantage of being simple and backward compatible. They also have some drawbacks:

* with #67, scrollbars may easily break the modal design
* with #75, scrolling the modal also scrolls the body behind

Here's a third approach, so that you can make your choice ;)

This approach is the one you've been described [here](https://github.com/kylefox/jquery-modal/issues/69#issuecomment-32999106). It works well with overflowing content, but it has the disadvantage to break a few things and thus, not to be backward compatible. Here's the list of changes:

1. `.modal` is wrapped inside `.blocker`
2. `.modal` is horizontally and vertically centered using CSS (cf. the ghost technique described [here](https://css-tricks.com/centering-in-the-unknown/))
3. `overflow: hidden` is applied to the document body when the modal is displayed

Here are the consequences of those changes:
* `.blocker` can't be styled in JS only, because of the ghost technique. So it has to appear in the plugin stylesheet. Also, we can't apply opacity on it anymore, now that it contains the modal, so this has to be replaced with CSS `rgba()`. That also means we can drop the `overlay` and `opacity` options.
* since centering is performed using CSS instead of JS, the plugin will probably fail to work on IE<8. That also mean the `center()` method can be dropped.

If you decide to go with this solution, some extra cleanup should follow (mainly remove `center()`, `overlay` and `opacity` from the docs and the examples). I can take care of it if you need.