### PR TITLE
Added main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "jquery-modal",
   "version": "0.5.7",
+  "main": "jquery.model.js",
   "description": "The simplest possible modal for jQuery",
   "homepage": "https://github.com/kylefox/jquery-modal",
   "repository": "kylefox/jquery-modal",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jquery-modal",
   "version": "0.5.7",
-  "main": "jquery.model.js",
+  "main": "jquery.modal.js",
   "description": "The simplest possible modal for jQuery",
   "homepage": "https://github.com/kylefox/jquery-modal",
   "repository": "kylefox/jquery-modal",


### PR DESCRIPTION
Hi,

Just installed the package via npm; this is a follow-up PR to #107. Adding the `main` property allows the package to be required by tools like Browserify, e.g.:

```
require('jquery-modal');
```