### PR TITLE
Pass arguments to AJAX_SUCCESS and AJAX_FAIL

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ The following events are triggered when AJAX modals are requested.
     $.modal.AJAX_FAIL = 'modal:ajax:fail';
     $.modal.AJAX_COMPLETE = 'modal:ajax:complete';
 
-The handlers receive no arguments. The events are triggered on the `<a>` element which initiated the AJAX modal.
+The handlers receive the same arguments as the jQuery `jqXHR.done()` and `jqXHR.fail()` promise methods. The events are triggered on the `<a>` element which initiated the AJAX modal.
 
 ## More advanced AJAX handling
 

--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -28,13 +28,13 @@
         el.trigger($.modal.AJAX_SEND);
         $.get(target).done(function(html) {
           if (!current) return;
-          el.trigger($.modal.AJAX_SUCCESS);
+          el.trigger($.modal.AJAX_SUCCESS,arguments);
           current.$elm.empty().append(html).on($.modal.CLOSE, remove);
           current.hideSpinner();
           current.open();
           el.trigger($.modal.AJAX_COMPLETE);
         }).fail(function() {
-          el.trigger($.modal.AJAX_FAIL);
+          el.trigger($.modal.AJAX_FAIL,arguments);
           current.hideSpinner();
           el.trigger($.modal.AJAX_COMPLETE);
         });


### PR DESCRIPTION
Usage:
```js
$('#ajax-link').on('modal:ajax:fail',function(jqXHR,textStatus,errorThrown){
  //analyze here why ajax failed
});
```