### PR TITLE
Smart close: check if we're destroying the right instance

### DIFF
--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -69,9 +69,9 @@
     },
 
     close: function() {
+      $(document).off('keydown.modal');
       this.unblock();
       this.hide();
-      $(document).off('keydown.modal');
     },
 
     block: function() {
@@ -166,9 +166,10 @@
   $.modal.close = function(event) {
     if (!current) return;
     if (event) event.preventDefault();
-    current.close();
     var that = current.$elm;
-    current = null;
+    current.close();
+    if (that.is(current.$elm))
+        current = null;
     return that;
   };
 


### PR DESCRIPTION
Since the plugin handles only one modal at a time, the need may arise to have one `modal:close` trigger another `modal:open` in order to implement state management. Here's an example:
```js
$modal1.on('modal:close',function(){
  $modal2.modal();
});
```
This doesn't play nicely with the current codebase: `$modal2` shows up but stop responding afterwards (uncloseable). The reason is that the `current` instance gets destroyed by the first modal `close()` call.

This PR intends to fix that by adding a simple check before destroying the `current` instance.

NB: Unsubscribing to `keydown.modal` is performed a bit earlier for the same reason: `this.hide()` may trigger another `modal:open`.