### PR TITLE
#120: Race condition fix

### DIFF
--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -54,7 +54,9 @@
       if(this.options.doFade) {
         this.block();
         setTimeout(function() {
-          m.show();
+          if ($.modal.isActive()) {
+            m.show();                
+          }
         }, this.options.fadeDuration * this.options.fadeDelay);
       } else {
         this.block();


### PR DESCRIPTION
Modal is only opened after a fade animation completes if the dialog state is still considered "active".
