### PR TITLE
add callback to show() method

### DIFF
--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -111,9 +111,9 @@
       this.$elm.addClass(this.options.modalClass + ' current');
       this.center();
       if(this.options.doFade) {
-        this.$elm.fadeIn(this.options.fadeDuration);
-      } else {
-        this.$elm.show();
+        this.$elm.fadeIn(this.options.fadeDuration, this.options.showCallback);
+      } else {		  
+        this.$elm.show(0, this.options.showCallback);
       }
       this.$elm.trigger($.modal.OPEN, [this._ctx()]);
     },
@@ -199,6 +199,7 @@
     spinnerHtml: null,
     showSpinner: true,
     showClose: true,
+	showCallback: function(){},
     fadeDuration: null,   // Number of milliseconds the fade animation takes.
     fadeDelay: 1.0        // Point during the overlay's fade-in that the modal begins to fade in (.5 = 50%, 1.5 = 150%, etc.)
   };


### PR DESCRIPTION
I needed to have some code run after a modal fades in - specifically it was causing issues with chart.js canvas charts. If the canvas element is hidden when the chart is drawn, then the chart fails to render

I can now add a callback like so: 

    $('a[href="#ex8"]').click(function(event) {
      event.preventDefault();
      $(this).modal({
        fadeDuration: 1000,
        fadeDelay: 0.50,
        showCallback: function(){ alert("finished fading in"); } 
      });
    });

