### PR TITLE
Bugfix: modal always fading

### DIFF
--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -129,7 +129,7 @@
           _this.$elm.trigger($.modal.AFTER_CLOSE, [_this._ctx()]);
         });
       } else {
-        this.$elm.hide(function () {
+        this.$elm.hide(0, function () {
           _this.$elm.trigger($.modal.AFTER_CLOSE, [_this._ctx()]);
         });
       }


### PR DESCRIPTION
Commit fc55c9ef85eefe7eda46e2d4b077539e4df04254 has introduced a default 400ms fading (cf. jQuery [docs](http://api.jquery.com/hide/)).

This PR fixes that.