### PR TITLE
Display modal without binding element

### DIFF
--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -43,7 +43,7 @@
       while ($.modal.isActive())
         $.modal.close(); // Close any open modals.
     modals.push(this);
-    if (el.is('a')) {
+    if ((el instanceof $) && el.is('a')) {
       target = el.attr('href');
       //Select element by id from href
       if (/^#/.test(target)) {


### PR DESCRIPTION
Display the modal calling $.modal('some content',{option:value}) without bind an html element. Useful for open a modal on an ajax response for exemple. Just 4 small lines to add.