### PR TITLE
Support for jQuery 3.x

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "modal"
   ],
   "dependencies": {
-    "jquery": "1.8.0 - 2.1.x"
+    "jquery": "1.8.0 - 3.1.x"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
I'm not fully sure what repercussions this has, local manual testing still works as expected but I do not have intimate knowledge of how the plugin works to say for certain whether the plugin uses jQuery in a way that is incompatible with jQuery 3.1.