### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ $.modal.AFTER_CLOSE = 'modal:after-close';      // Fires after the modal has ful
 The first and only argument passed to these event handlers is the `modal` object, which has three properties:
 
 ```js
-modal.$elm;       // Original jQuery object upon which modal() was invoked.
+modal.elm;       // Original jQuery object upon which modal() was invoked.
 modal.options;    // Options passed to the modal.
 modal.$blocker;   // The overlay element.
 ```


### PR DESCRIPTION
I use jquery.modal version 0.8.0.
Why I've made changes in readme is in the code section below.

```
$('#container').on($.modal.BEFORE_OPEN, function(event, modal) {
    // prints undefined
    console.log(modal.$elm);    
    // without dollar sign it works
    console.log(modal.elm);
    // blocker works with dollar sign 
    console.log(modal.$blocker);
});
```

Maybe it will be ok to skip this request prior to some twiks in code to unify properties name (i.e. make working `modal.$elm` and `modal.$blocker` (or `modal.elm` and `modal.blocker`)).