### PR TITLE
Fix #198 pressing enter key on modal

### DIFF
--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -93,6 +93,7 @@
       $(document).off('keydown.modal').on('keydown.modal', function(event) {
         var current = getCurrent();
         if (event.which === 27 && current.options.escapeClose) current.close();
+        if (event.which === 13) return false
       });
       if (this.options.clickClose)
         this.$blocker.click(function(e) {

--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -41,6 +41,7 @@
     modals.push(this);
     if (el.is('a')) {
       target = el.attr('href');
+      this.anchor = el;
       //Select element by id from href
       if (/^#/.test(target)) {
         this.$elm = $(target);
@@ -83,6 +84,7 @@
     open: function() {
       var m = this;
       this.block();
+      this.anchor.blur();
       if(this.options.doFade) {
         setTimeout(function() {
           m.show();
@@ -93,7 +95,6 @@
       $(document).off('keydown.modal').on('keydown.modal', function(event) {
         var current = getCurrent();
         if (event.which === 27 && current.options.escapeClose) current.close();
-        if (event.which === 13) return false
       });
       if (this.options.clickClose)
         this.$blocker.click(function(e) {


### PR DESCRIPTION
Fixed using `blur()` on the anchor. This should solve the previous commit issue of allowing the enter key to be used throughout.