### PR TITLE
Update jquery.modal.js

### DIFF
--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -73,6 +73,7 @@
       }
     } else {
       this.$elm = el;
+      this.anchor = el;
       this.$body.append(this.$elm);
       this.open();
     }


### PR DESCRIPTION
if the popup is triggered using jquery .modal() and not via a link, line 88 throws an error because the anchor variable is not set