### PR TITLE
Avoid having to set inline styles to hide modal by default. Fix #186

### DIFF
--- a/jquery.modal.css
+++ b/jquery.modal.css
@@ -21,7 +21,7 @@
   background-color: transparent;
 }
 .modal {
-  display: inline-block;
+  display: none;
   vertical-align: middle;
   position: relative;
   z-index: 2;

--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -73,6 +73,7 @@
       }
     } else {
       this.$elm = el;
+      this.anchor = el;
       this.$body.append(this.$elm);
       this.open();
     }
@@ -143,9 +144,9 @@
       }
       this.$elm.addClass(this.options.modalClass).appendTo(this.$blocker);
       if(this.options.doFade) {
-        this.$elm.css('opacity',0).show().animate({opacity: 1}, this.options.fadeDuration);
+        this.$elm.css({opacity: 0, display: 'inline-block'}).animate({opacity: 1}, this.options.fadeDuration);
       } else {
-        this.$elm.show();
+        this.$elm.css('display', 'inline-block');
       }
       this.$elm.trigger($.modal.OPEN, [this._ctx()]);
     },


### PR DESCRIPTION
Avoid having to set inline styles to hide modal. When modal show, it applies display: inline-block.
In CSS the ".modal" class has display: none.

This pull request also includes fix for anchor problem (issue #213).