### PR TITLE
Minor changes to remove warnings from jQuery 3.4.

### DIFF
--- a/jquery.modal.js
+++ b/jquery.modal.js
@@ -85,7 +85,7 @@
     open: function() {
       var m = this;
       this.block();
-      this.anchor.blur();
+      this.anchor.trigger('blur');
       if(this.options.doFade) {
         setTimeout(function() {
           m.show();
@@ -98,7 +98,7 @@
         if (event.which === 27 && current.options.escapeClose) current.close();
       });
       if (this.options.clickClose)
-        this.$blocker.click(function(e) {
+        this.$blocker.on('click', function(e) {
           if (e.target === this)
             $.modal.close();
         });


### PR DESCRIPTION
Not extensively tested, but it works. The jQuery 3.x migration tool highlighted this as deprecated.

I have never done a github pull on a multi-user project, so hopefully I didn't break any rules or miss any requirements. I didn't know if I should change the version in the file or not.